### PR TITLE
Update Azure OpenAI model name and version

### DIFF
--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -38,10 +38,10 @@ param deployAzureOpenAI bool = true
 param azureOpenAILocation string = location
 
 @description('value of azure openai model name')
-param chatCompletionModelName string = 'gpt-4o-mini'
+param chatCompletionModelName string = 'gpt-4.1-mini'
 
 @description('value of azure openai model version')
-param chatCompletionModelVersion string = '2024-07-18'
+param chatCompletionModelVersion string = '2025-04-14'
 
 @description('value of azure openai model capacity')
 param chatCompletionModelCapacity int = 8


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates the default Azure OpenAI model used in the infrastructure configuration to a newer version, ensuring the deployment uses the latest model and version.

Azure OpenAI model updates:

* Changed the default `chatCompletionModelName` from `'gpt-4o-mini'` to `'gpt-4.1-mini'` in `main.bicep`.
* Updated the default `chatCompletionModelVersion` from `'2024-07-18'` to `'2025-04-14'` in `main.bicep`.
